### PR TITLE
Expand client lifecycle management & add error response

### DIFF
--- a/draft-kasselman-oauth_spiffe.md
+++ b/draft-kasselman-oauth_spiffe.md
@@ -223,8 +223,22 @@ An authorization server MAY register a client with a default set of scopes or re
 ## Grant Types
 Authorization servers MAY choose to limit the grant types for which the "register on first use" pattern is supported. This may be recorded as the "grant_type" metadata field.
 
-# Client Lifecycle Management
-The number of clients registered with an authorization server may grow significantly over time. An authorization MAY unregistered a client if it has not been used for an extended period of time to reduce the size of the client registration database.
+# Post-Registration Client Lifecycle Management
+After registration there MUST be an initial client record with a direct link between the SPIFFE identifier in the SPIFFE credentials and the OAuth client identifier, but additional work MAY be required to make the client operational. The client might be missing configuration or entitlement. This is particularly relevant for complex enterprise environments.
+
+## Configuration
+After registration a client must be configured with the necessary operational metadata to function correctly and securely. An authorization server may use a number of mechanissms for obtaining metadata. Metadata may be statically preconfigured, automatically or manually created, or retrieved from a configuration management system. This can happen instantaneously after registration or it can be asyncronous. The OAuth 2.0 Dynamic Client Registration Protocol {{RFC7591}} defines client metadata that may be used, however there can also be custom metadata.
+
+## Entitlement
+This defines the specific permissions and/or access rights granted to the client. This is a critical stage that determines what the configured client is permitted to do and request. Entitlements can include; grant types, scopes, audience restrictions, or fine-grained permissions. 
+
+In enterprise environments the permissions and access rights granted to a client can be highly dynamic and complex. As such there might be several out of band operations; assigning permissions and roles to the client in a PRP system, assigning attributes to the workload, or any other mechanism used for making access rights evaluations.
+
+## Updates
+It is possible that updates to client configuration or entitlement happens with the same mechanism as "register on first use", and can even be entirely opague to the workload. However special care must be taken to ensure this happens securely and in line with company policies. If entitlements like client permissions can be updated dynamically you need to be aware that this can lead to potential priviledge escalation if a workload is hijacked. Similarly adding new redirects to an existing client can also lead to potential issues. The implementer needs to make clear decisions if a) updates to clients are allowed and b) what types of updates are allowed. Risk analysis could also be introduced to control client updates.
+
+## Deregistration
+The number of clients registered with an authorization server may grow significantly over time. An authorization server MAY unregistered a client if it has not been used for an extended period of time to reduce the size of the client registration database. An authorization server MAY also implement an automated expiry of clients (TTL), which has the benefit of continous re-registration and automatic cleanup of unused clients.
 
 # Security Considerations
 

--- a/draft-kasselman-oauth_spiffe.md
+++ b/draft-kasselman-oauth_spiffe.md
@@ -241,7 +241,7 @@ Authorization servers MAY choose to limit the grant types for which the "registe
 After registration, there MUST be an initial client record with a direct link between the SPIFFE identifier in the SPIFFE credentials and the OAuth client identifier. However, additional steps MAY be required to make the client operational, such as missing configuration or entitlement information. This is particularly relevant for complex enterprise environments.
 
 ## Configuration
-After registration, a client must be configured with the necessary operational metadata to function correctly and securely. An authorization server may use a number of mechanisms for obtaining metadata. Metadata may be statically preconfigured, automatically or manually created, or retrieved from a configuration management system. This can happen instantaneously after registration or it can be asynchronous.
+After registration, a client MUST be configured with the necessary operational metadata to function correctly and securely. An authorization server may use a number of mechanisms for obtaining metadata. Metadata may be statically preconfigured, automatically or manually created, or retrieved from a configuration management system. This can happen instantaneously after registration or it can be asynchronous. If metadata is added asynchronously, the authorization server MUST return an "Incomplete Registration" error whenever the client interacts with the authorization server, until the additional metadata has been added.
 
 ## Entitlement
 Entitlement defines the specific permissions and/or access rights granted to the client. This is a critical stage that determines what the configured client is permitted to do and request. Entitlements can include; grant types, scopes, audience restrictions, or fine-grained permissions.
@@ -249,14 +249,18 @@ Entitlement defines the specific permissions and/or access rights granted to the
 In enterprise environments, the permissions and access rights granted to a client can be highly dynamic and complex. As such, there might be several out-of-band operations; creating a principal for the client, assigning permissions and roles to the client in a PRP system, assigning attributes to the workload, or any other mechanism used for making access rights evaluations.
 
 ## Updates
-Updates to client configuration or entitlement may occur using the same "register on first use" mechanism and can even be entirely opaque to the workload. However, special care must be taken to ensure this happens securely and in line with organizational policies. If entitlements, such as client permissions, can be updated dynamically, be aware that this can lead to potential privilege escalation if a workload is compromised. Similarly, adding new redirects to an existing client can also lead to potential issues. The implementer needs to make clear decisions on whether updates to clients are allowed and, if so, what types of updates are permitted. Risk analysis could also be introduced to determine what types of client updates are allowed.
+Updates to client configuration or entitlement may occur using the same "register on first use" mechanism and can even be entirely opaque to the workload. However, special care must be taken to ensure this happens securely and in line with organizational policies.
 
 ## Deregistration
-The number of clients registered with an authorization server may grow significantly over time. An authorization server MAY deregister a client if it has not been used for an extended period to reduce the size of the client registration database. An authorization server MAY also implement an automated expiry of clients (TTL), which has the benefit of continuous re-registration and automatic cleanup of unused clients.
+An authorization server MAY automatically expire clients. This avoids a large number of unused clients identifiers from accumulating. If a client identifier is deleted, it can re-register using the "register-on-first-use" pattern described in this document.
 
 # Security Considerations
 
 TODO: Security. Consider discussing error responses (include enough info to be helpful, but not too much to aid attackers.)
+
+## Entitlement Updates
+
+If entitlement updates, such as client permissions, can be updated dynamically, be aware that this can lead to potential privilege escalation if a workload is compromised. Similarly, adding new redirects to an existing client can also lead to potential issues. The implementer needs to make clear decisions on whether updates to clients are allowed and, if so, what types of updates are permitted. Risk analysis could also be introduced to determine what types of client updates are allowed.
 
 
 # IANA Considerations

--- a/draft-kasselman-oauth_spiffe.md
+++ b/draft-kasselman-oauth_spiffe.md
@@ -194,14 +194,16 @@ In OAuth flows that rely on redirection, the initial interaction with the author
 ## Client Registration Error Response
 When the registration attempt has failed or been rejected, the authorization server MUST return an error response that conforms to the expected error response for the given OAuth 2.0 endpoint. Additional error information may or may not be included in the error response.
 
+TODO: Generally improve error section, inline with RFC 6749. Consider also how to return information which can aid the workload or workload owners to resolve failed registration or complete an incomplete registration.
+
 ### Authentication Failed
-When a SPIFFE credential is missing, invalid, or for any reason rejected, the authorization server returns an error response with an HTTP 401 status code. Care must be taken to return enough useful information, but not so much as to potentially aid malicious actors.
+When a SPIFFE credential is missing, invalid, or for any reason rejected, the authorization server returns an error response with an HTTP 401 status code.
 
 ### Failed Registration
-When a request to register a client fails due to disallowed metadata (e.g., http redirect URIs if only https is allowed, or an access token lifetime exceeding maximum allowed) or invalid metadata, the authorization server returns an error response with an HTTP 400 status code. The error response should indicate what was invalid or disallowed, and ideally how it can be resolved.
+When a request to register a client fails due to disallowed metadata (e.g., http redirect URIs if only https is allowed, or an access token lifetime exceeding maximum allowed) or invalid metadata, the authorization server returns an error response with an HTTP 400 status code.
 
 ### Incomplete Registration
-When additional post-registration setup is required, there can be cases where the client cannot be used. In such scenarios, the authorization server returns an error response with an HTTP 403 status code. This error could also be returned in cases where there is an asynchronous event or manual operation that is not yet completed. The response may also include information about what is missing and potentially how the workload, or workload owners, can complete the registration.
+When additional post-registration setup is required, there can be cases where the client cannot be used. In such scenarios, the authorization server returns an error response with an HTTP 403 status code. This error could also be returned in cases where there is an asynchronous event or manual operation that is not yet completed.
 
 # SPIFFE and OAuth Trust Relationship
 SPIFFE makes provision for multiple Trust Domains, which are represented in the workload identifier. Trust Domains offers additional segmentation withing a SPIFFE deployment and each Trust Domain has its own keys for signing credentials. The OAuth authorization server may choose to trust one or more trust domains as defined in {{SPIFFE-OAUTH-CLIENT-AUTH}}.
@@ -236,7 +238,7 @@ An authorization server MAY register a client with a default set of scopes or re
 Authorization servers MAY choose to limit the grant types for which the "register on first use" pattern is supported. This may be recorded as the "grant_type" metadata field.
 
 # Post-Registration Client Lifecycle Management
-After registration, there MUST be an initial client record with a direct link between the SPIFFE identifier in the SPIFFE credentials and the OAuth client identifier. However, additional work MAY be required to make the client operational, such as missing configuration or entitlement. This is particularly relevant for complex enterprise environments.
+After registration, there MUST be an initial client record with a direct link between the SPIFFE identifier in the SPIFFE credentials and the OAuth client identifier. However, additional steps MAY be required to make the client operational, such as missing configuration or entitlement information. This is particularly relevant for complex enterprise environments.
 
 ## Configuration
 After registration, a client must be configured with the necessary operational metadata to function correctly and securely. An authorization server may use a number of mechanisms for obtaining metadata. Metadata may be statically preconfigured, automatically or manually created, or retrieved from a configuration management system. This can happen instantaneously after registration or it can be asynchronous.
@@ -254,7 +256,7 @@ The number of clients registered with an authorization server may grow significa
 
 # Security Considerations
 
-TODO Security
+TODO: Security. Consider discussing error responses (include enough info to be helpful, but not too much to aid attackers.)
 
 
 # IANA Considerations

--- a/draft-kasselman-oauth_spiffe.md
+++ b/draft-kasselman-oauth_spiffe.md
@@ -194,13 +194,13 @@ In OAuth flows that rely on redirection, the initial interaction with the author
 ## Client Registration Error Response
 When the registration attempt has failed or been rejected, the authorization server MUST return an error response that conforms to the expected error response for the given OAuth 2.0 endpoint. Additional error information may or may not be included in the error response.
 
-## Authentication Failed
+### Authentication Failed
 When a SPIFFE credential is missing, invalid, or for any reason not valid, the authorization server returns an error response with an HTTP 401 status code. Care must be taken to return enough useful information, but not so much as to potentially aid malicious actors.
 
-## Failed Registration
+### Failed Registration
 When a request to register a client fails due to disallowed metadata (e.g., http redirect URIs if only https is allowed, or an access token lifetime exceeding maximum allowed) or invalid metadata, the authorization server returns an error response with an HTTP 400 status code. The error response should indicate what was invalid or disallowed, and ideally how it can be resolved.
 
-## Incomplete Registration
+### Incomplete Registration
 When additional post-registration setup is required, there can be cases where the client cannot be used. In such scenarios, the authorization server returns an error response with an HTTP 403 status code. This error could also be returned in cases where there is an asynchronous event or manual operation that is not yet completed. The response may also include information about what is missing and potentially how the workload, or workload owners, can complete the registration.
 
 # SPIFFE and OAuth Trust Relationship

--- a/draft-kasselman-oauth_spiffe.md
+++ b/draft-kasselman-oauth_spiffe.md
@@ -195,7 +195,7 @@ In OAuth flows that rely on redirection, the initial interaction with the author
 When the registration attempt has failed or been rejected, the authorization server MUST return an error response that conforms to the expected error response for the given OAuth 2.0 endpoint. Additional error information may or may not be included in the error response.
 
 ### Authentication Failed
-When a SPIFFE credential is missing, invalid, or for any reason not valid, the authorization server returns an error response with an HTTP 401 status code. Care must be taken to return enough useful information, but not so much as to potentially aid malicious actors.
+When a SPIFFE credential is missing, invalid, or for any reason rejected, the authorization server returns an error response with an HTTP 401 status code. Care must be taken to return enough useful information, but not so much as to potentially aid malicious actors.
 
 ### Failed Registration
 When a request to register a client fails due to disallowed metadata (e.g., http redirect URIs if only https is allowed, or an access token lifetime exceeding maximum allowed) or invalid metadata, the authorization server returns an error response with an HTTP 400 status code. The error response should indicate what was invalid or disallowed, and ideally how it can be resolved.


### PR DESCRIPTION
* Greatly expands section 6, changes title to "Post-Registration Client Lifecycle Management".
* Introduces more granular client lifecycle stages.
* Adds section "Client Registration Error Response".

Resolves #17 & #18 